### PR TITLE
Allows two-way binding to access current card type

### DIFF
--- a/src/angular-creditcard-flag.js
+++ b/src/angular-creditcard-flag.js
@@ -12,14 +12,14 @@ angular.module('angular-creditcard-flag',[])
             el[0].insertAdjacentHTML('afterend','<span class="_flag"></span>');
             function flag(el) {
                 var c = {
-                    'amex' : [34,37],
-                    'elo' : [636368, 438935,504175,451416,636297,5067,4576,4011],
                     'visa' : [4],
                     'master' : [51,52,53,54,55,677189],
+                    'amex' : [34,37],
+                    'discover' : [6011,622,64,65],
+                    'elo' : [636368, 438935,504175,451416,636297,5067,4576,4011],
                     'diners' : [300,301,302,303,304,305,309,2014,2149,36,38,39],
                     'hipercard' : [60],
                     'aura' : [50],
-                    'discover' : [6011,622,64,65],
                     'jcb' : [35]
                 };
                 var matched = false;

--- a/src/angular-creditcard-flag.js
+++ b/src/angular-creditcard-flag.js
@@ -4,6 +4,9 @@ angular.module('angular-creditcard-flag',[])
     .directive('creditcardFlag', function() {
       return {
         restrict: 'A',
+        scope: {
+          creditcardTypeModel: '=?'
+        },
         link: function($scope, el) {
             el.addClass('card-flag');
             el[0].insertAdjacentHTML('afterend','<span class="_flag"></span>');
@@ -30,9 +33,11 @@ angular.module('angular-creditcard-flag',[])
                             if(cleanNumber.match(r)){
                                 matched = true;
                                 el[0].className = css.replace(remove,'').concat(' card-flag-'+a);
+                                $scope.ccTypeModel = a;
                                 break;
                             }else{
                                 el[0].className = css.replace(remove,'');
+                                $scope.ccTypeModel = 'none';
                             }
                         }
                     }


### PR DESCRIPTION
new creditcard-type-model optional attribute that will accept a model to bind to

Example:

```html
<input type="text" name="ccNumber" ng-model="paymentCtrl.ccNumber" creditcard-type-model="paymentCtrl.ccType" creditcard-flag>
```